### PR TITLE
Support Basic Authentication with AFMAuthHandler

### DIFF
--- a/afm/auth.py
+++ b/afm/auth.py
@@ -1,0 +1,31 @@
+import pyarrow.flight as fl
+from pyarrow.lib import tobytes
+
+class AFMAuthHandler(fl.ServerAuthHandler):
+    def __init__(self, auth_config):
+        super().__init__()
+        if not auth_config:
+            self.type = 'none'
+        elif 'basic' in auth_config:
+            self.type = 'basic'
+            self.creds = auth_config['basic'].get('credentials', None)
+        else:
+            raise NotImplementedError("Unknown authenticaion type")
+
+    def authenticate(self, outgoing, incoming):
+        buf = incoming.read()
+        auth = fl.BasicAuth.deserialize(buf)
+        if self.type == 'basic':
+            if auth.username not in self.creds:
+                raise fl.FlightUnauthenticatedError("unknown user")
+            if self.creds[auth.username] != auth.password:
+                raise fl.FlightUnauthenticatedError("wrong password")
+        outgoing.write(tobytes(auth.username))
+
+    def is_valid(self, token):
+        if self.type == 'basic':
+            if not token:
+                raise fl.FlightUnauthenticatedError("token not provided")
+            if token not in self.creds:
+                raise fl.FlightUnauthenticatedError("unknown user")
+        return token

--- a/afm/auth.py
+++ b/afm/auth.py
@@ -16,9 +16,9 @@ class AFMAuthHandler(fl.ServerAuthHandler):
         buf = incoming.read()
         auth = fl.BasicAuth.deserialize(buf)
         if self.type == 'basic':
-            if auth.username not in self.creds:
+            if str(auth.username.decode()) not in self.creds:
                 raise fl.FlightUnauthenticatedError("unknown user")
-            if self.creds[auth.username] != auth.password:
+            if self.creds[auth.username.decode()] != auth.password.decode():
                 raise fl.FlightUnauthenticatedError("wrong password")
         outgoing.write(tobytes(auth.username))
 
@@ -26,6 +26,6 @@ class AFMAuthHandler(fl.ServerAuthHandler):
         if self.type == 'basic':
             if not token:
                 raise fl.FlightUnauthenticatedError("token not provided")
-            if token not in self.creds:
+            if token.decode() not in self.creds:
                 raise fl.FlightUnauthenticatedError("unknown user")
         return token

--- a/afm/auth.py
+++ b/afm/auth.py
@@ -1,44 +1,6 @@
 from pyarrow import flight
 from pyarrow.flight import ServerAuthHandler
-
-# taken from https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L508
-class NoopAuthHandler(ServerAuthHandler):
-    """A no-op auth handler."""
-
-    def authenticate(self, outgoing, incoming):
-        outgoing.write("")
-        """Do nothing."""
-
-    def is_valid(self, token):
-        """
-        Returning an empty string.
-        Returning None causes Type error.
-        """
-        return ""
-
-# taken from https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L426
-class HttpBasicServerAuthHandler(ServerAuthHandler):
-    """An example implementation of HTTP basic authentication."""
-
-    def __init__(self, creds):
-        super().__init__()
-        self.creds = creds
-
-    def authenticate(self, outgoing, incoming):
-        buf = incoming.read()
-        auth = flight.BasicAuth.deserialize(buf)
-        if auth.username.decode() not in self.creds:
-            raise flight.FlightUnauthenticatedError("unknown user")
-        if self.creds[auth.username.decode()] != auth.password.decode():
-            raise flight.FlightUnauthenticatedError("wrong password")
-        outgoing.write(auth.username)
-
-    def is_valid(self, token):
-        if not token:
-            raise flight.FlightUnauthenticatedError("token not provided")
-        if token.decode() not in self.creds:
-            raise flight.FlightUnauthenticatedError("unknown user")
-        return token
+from .auth_handlers.auth_servers import NoopAuthHandler, HttpBasicServerAuthHandler
 
 class AFMAuthHandler(ServerAuthHandler):
     def __init__(self, auth_config):

--- a/afm/auth.py
+++ b/afm/auth.py
@@ -1,31 +1,57 @@
-import pyarrow.flight as fl
-from pyarrow.lib import tobytes
+from pyarrow import flight
+from pyarrow.flight import ServerAuthHandler
 
-class AFMAuthHandler(fl.ServerAuthHandler):
+# taken from https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L508
+class NoopAuthHandler(ServerAuthHandler):
+    """A no-op auth handler."""
+
+    def authenticate(self, outgoing, incoming):
+        outgoing.write("")
+        """Do nothing."""
+
+    def is_valid(self, token):
+        """
+        Returning an empty string.
+        Returning None causes Type error.
+        """
+        return ""
+
+# taken from https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L426
+class HttpBasicServerAuthHandler(ServerAuthHandler):
+    """An example implementation of HTTP basic authentication."""
+
+    def __init__(self, creds):
+        super().__init__()
+        self.creds = creds
+
+    def authenticate(self, outgoing, incoming):
+        buf = incoming.read()
+        auth = flight.BasicAuth.deserialize(buf)
+        if auth.username.decode() not in self.creds:
+            raise flight.FlightUnauthenticatedError("unknown user")
+        if self.creds[auth.username.decode()] != auth.password.decode():
+            raise flight.FlightUnauthenticatedError("wrong password")
+        outgoing.write(auth.username)
+
+    def is_valid(self, token):
+        if not token:
+            raise flight.FlightUnauthenticatedError("token not provided")
+        if token.decode() not in self.creds:
+            raise flight.FlightUnauthenticatedError("unknown user")
+        return token
+
+class AFMAuthHandler(ServerAuthHandler):
     def __init__(self, auth_config):
         super().__init__()
         if not auth_config:
-            self.type = 'none'
+            self.auth_handler = NoopAuthHandler()
         elif 'basic' in auth_config:
-            self.type = 'basic'
-            self.creds = auth_config['basic'].get('credentials', None)
+            self.auth_handler = HttpBasicServerAuthHandler(auth_config['basic'].get('credentials', None))
         else:
             raise NotImplementedError("Unknown authenticaion type")
 
     def authenticate(self, outgoing, incoming):
-        buf = incoming.read()
-        auth = fl.BasicAuth.deserialize(buf)
-        if self.type == 'basic':
-            if str(auth.username.decode()) not in self.creds:
-                raise fl.FlightUnauthenticatedError("unknown user")
-            if self.creds[auth.username.decode()] != auth.password.decode():
-                raise fl.FlightUnauthenticatedError("wrong password")
-        outgoing.write(tobytes(auth.username))
+        self.auth_handler.authenticate(outgoing, incoming)
 
     def is_valid(self, token):
-        if self.type == 'basic':
-            if not token:
-                raise fl.FlightUnauthenticatedError("token not provided")
-            if token.decode() not in self.creds:
-                raise fl.FlightUnauthenticatedError("unknown user")
-        return token
+        return self.auth_handler.is_valid(token)

--- a/afm/auth_handlers/auth_servers.py
+++ b/afm/auth_handlers/auth_servers.py
@@ -1,0 +1,41 @@
+from pyarrow import flight
+from pyarrow.flight import ServerAuthHandler
+
+# taken from https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L508
+class NoopAuthHandler(ServerAuthHandler):
+    """A no-op auth handler."""
+
+    def authenticate(self, outgoing, incoming):
+        outgoing.write("")
+        """Do nothing."""
+
+    def is_valid(self, token):
+        """
+        Returning an empty string.
+        Returning None causes Type error.
+        """
+        return ""
+
+# taken from https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L426
+class HttpBasicServerAuthHandler(ServerAuthHandler):
+    """An example implementation of HTTP basic authentication."""
+
+    def __init__(self, creds):
+        super().__init__()
+        self.creds = creds
+
+    def authenticate(self, outgoing, incoming):
+        buf = incoming.read()
+        auth = flight.BasicAuth.deserialize(buf)
+        if auth.username.decode() not in self.creds:
+            raise flight.FlightUnauthenticatedError("unknown user")
+        if self.creds[auth.username.decode()] != auth.password.decode():
+            raise flight.FlightUnauthenticatedError("wrong password")
+        outgoing.write(auth.username)
+
+    def is_valid(self, token):
+        if not token:
+            raise flight.FlightUnauthenticatedError("token not provided")
+        if token.decode() not in self.creds:
+            raise flight.FlightUnauthenticatedError("unknown user")
+        return token

--- a/afm/config.py
+++ b/afm/config.py
@@ -19,8 +19,12 @@ class Config:
             "Requested config for undefined asset: {}".format(asset_name))
 
     @property
-    def workers(self) -> dict:
+    def workers(self) -> list:
         return self.values.get('workers', [])
+
+    @property
+    def auth(self) -> dict:
+        return self.values.get('auth', {})
 
     def __enter__(self):
         return self

--- a/afm/server.py
+++ b/afm/server.py
@@ -20,10 +20,23 @@ from .pep import transform, transform_schema, actions
 from .ticket import AFMTicket
 from .worker import workers_from_config
 
+class myAuthHandler(fl.ServerAuthHandler):
+    def __init__(self):
+         super().__init__()
+
+    def authenticate(self, outgoing, incoming):
+        buf = incoming.read()
+        auth = flight.BasicAuth.deserialize(buf)
+        outgoing.write(tobytes(auth.username))
+
+    def is_valid(self, token):
+        return token
+
 class AFMFlightServer(fl.FlightServerBase):
     def __init__(self, config_path: str, port: int, *args, **kwargs):
         super(AFMFlightServer, self).__init__(
-            "grpc://0.0.0.0:{}".format(port), *args, **kwargs)
+            "grpc://0.0.0.0:{}".format(port), auth_handler=myAuthHandler(),
+            *args, **kwargs)
         self.config_path = config_path
 
     def _get_dataset(self, asset):

--- a/afm/server.py
+++ b/afm/server.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 import pyarrow.csv as csv
 import pyarrow.dataset as ds
 from pyarrow.fs import FileSelector
+from pyarrow.lib import tobytes
 
 from .asset import asset_from_config
 from .command import AFMCommand
@@ -26,7 +27,7 @@ class myAuthHandler(fl.ServerAuthHandler):
 
     def authenticate(self, outgoing, incoming):
         buf = incoming.read()
-        auth = flight.BasicAuth.deserialize(buf)
+        auth = fl.BasicAuth.deserialize(buf)
         outgoing.write(tobytes(auth.username))
 
     def is_valid(self, token):

--- a/sample/sample.yaml
+++ b/sample/sample.yaml
@@ -1,3 +1,10 @@
+auth:
+  basic:
+    credentials:
+    - username: "qqq"
+      password: "moo"
+    - username: "user"
+      password: "password"
 workers:
   - name: "main"
     address: "localhost"

--- a/sample/sample.yaml
+++ b/sample/sample.yaml
@@ -1,10 +1,8 @@
 auth:
   basic:
     credentials:
-    - username: "qqq"
-      password: "moo"
-    - username: "user"
-      password: "password"
+      qqq: "moo"
+      user: "password"
 workers:
   - name: "main"
     address: "localhost"


### PR DESCRIPTION
AFMAuthHandler supports both 'basic' and 'none'
in the 'basic' case, the token returned to the user is the the username (as in https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_flight.py#L426). Is that a problem?

In `sample/sample.py`, I copied the definition of class HttpBasicClientAuthHandler from `afm/flight/auth_handlers.py` . Is there a better way?