### PR TITLE
bring back schema column filtering

### DIFF
--- a/afm/server.py
+++ b/afm/server.py
@@ -58,6 +58,8 @@ class AFMFlightServer(fl.FlightServerBase):
         dataset, data_files = self._get_dataset(asset)
         scanner = ds.Scanner.from_dataset(dataset, columns=columns, batch_size=64*2**20)
         batches = scanner.to_batches()
+        if columns:
+            return self._filter_columns(dataset.schema, columns), batches
         return dataset.schema, batches
 
     def _get_endpoints(self, tickets, locations):


### PR DESCRIPTION
choose a subset of the columns.
Following the fix, we filter only the relevant columns
(in the schema, not just in the record batches)

Signed-off-by: CDORON@il.ibm.com <cdoron@lnx-arrow.sl.cloud9.ibm.com>